### PR TITLE
添加1.20的刷子和装备在羊驼上的地毯

### DIFF
--- a/src/main/resources/tags/carpet.json
+++ b/src/main/resources/tags/carpet.json
@@ -1,0 +1,20 @@
+{
+    "values": [
+        "minecraft:white_carpet",
+        "minecraft:orange_carpet",
+        "minecraft:magenta_carpet",
+        "minecraft:light_blue_carpet",
+        "minecraft:yellow_carpet",
+        "minecraft:lime_carpet",
+        "minecraft:pink_carpet",
+        "minecraft:gray_carpet",
+        "minecraft:light_gray_carpet",
+        "minecraft:cyan_carpet",
+        "minecraft:purple_carpet",
+        "minecraft:blue_carpet",
+        "minecraft:brown_carpet",
+		"minecraft:green_carpet",
+		"minecraft:red_carpet",
+		"minecraft:black_carpet"
+    ]
+}

--- a/src/main/resources/tags/off_hand_slot.json
+++ b/src/main/resources/tags/off_hand_slot.json
@@ -11,6 +11,7 @@
         "minecraft:bundle",
         "minecraft:shears",
         "minecraft:goat_horn",
-        "minecraft:spyglass"
+        "minecraft:spyglass",
+        "minecraft:brush"
     ]
 }


### PR DESCRIPTION
因为wiki上说地毯和马铠属于统一栏，地毯上的属性同样对羊驼生效（测过了）