### PR TITLE
fix get attribute

### DIFF
--- a/src/main/java/io/github/slimefunguguproject/bump/implementation/items/weapons/SoulSword.java
+++ b/src/main/java/io/github/slimefunguguproject/bump/implementation/items/weapons/SoulSword.java
@@ -2,6 +2,8 @@ package io.github.slimefunguguproject.bump.implementation.items.weapons;
 
 import javax.annotation.Nonnull;
 
+import io.github.slimefunguguproject.bump.utils.Attributes;
+
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
@@ -37,7 +39,7 @@ public class SoulSword extends SimpleSlimefunItem<ItemUseHandler> {
         return e -> {
             Player p = e.getPlayer();
             double health = p.getHealth();
-            double maxHealth = p.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+            double maxHealth = p.getAttribute(Attributes.get("max_health")).getBaseValue();
             int foodLevel = p.getFoodLevel();
 
             if (maxHealth <= health) {

--- a/src/main/java/io/github/slimefunguguproject/bump/implementation/setup/AppraiseSetup.java
+++ b/src/main/java/io/github/slimefunguguproject/bump/implementation/setup/AppraiseSetup.java
@@ -7,6 +7,8 @@ import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
+import io.github.slimefunguguproject.bump.utils.Attributes;
+
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.ConfigurationSection;
@@ -74,7 +76,7 @@ public final class AppraiseSetup {
                     .addValidSlimefunItemIds(validSlimefunItemIds);
 
                 for (String attr : attributes) {
-                    Attribute attribute = Attribute.valueOf(attr);
+                    Attribute attribute = Attributes.get(attr);
                     double min = attributesSection.getDouble(attr + ".min");
                     double max = attributesSection.getDouble(attr + ".max");
                     String weightStr = attributesSection.getString(attr + ".weight");

--- a/src/main/java/io/github/slimefunguguproject/bump/utils/Attributes.java
+++ b/src/main/java/io/github/slimefunguguproject/bump/utils/Attributes.java
@@ -1,0 +1,36 @@
+package io.github.slimefunguguproject.bump.utils;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.attribute.Attribute;
+
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Attributes {
+    @Nonnull
+    public static Attribute get(String key) {
+        key = key.toLowerCase();
+        key = key.replace("generic_", "generic.");
+        key = key.replace("player_", "player.");
+        key = key.replace("horse_", "horse.");
+        key = key.replace("zombie_", "zombie.");
+        Set<String> names = new HashSet<>();
+        String plain = key.contains(".") ? key.split("\\.")[1] : key;
+        names.add(key);
+        names.add(plain);
+        names.add("generic." + plain);
+        names.add("player." + plain);
+        names.add("horse." + plain);
+        names.add("zombie." + plain);
+        for (var s : names) {
+            var result = Registry.ATTRIBUTE.get(NamespacedKey.minecraft(s));
+            if (result != null) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
不再使用 [Attribute#valueOf(String)](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html#valueOf(java.lang.String)) 来读取 [Attribute](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html)

改为使用 [Registry#ATTRIBUTE](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Registry.html#ATTRIBUTE) 